### PR TITLE
Evict DanTup_tiler.test due to flakes

### DIFF
--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -1,7 +1,0 @@
-contact=danny@tuppeny.com
-fetch=git clone https://github.com/DanTup/tiler.git tests
-fetch=git -C tests checkout 0a5e5e1c01826852ce7fa26fa4abf5e0279689fc
-fetch=git -C tests submodule init
-fetch=git -C tests submodule update --recursive --remote
-update=.
-test=flutter test test


### PR DESCRIPTION
Experiencing the following flake:

```
| ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
| The following TestFailure object was thrown running a test:
|   Expected: one widget whose rasterized image matches golden image
| "test-maps/orientation/isometric_windows.png"
|   Actual: ?:<exactly one widget with type "RepaintBoundary" (ignoring offstage widgets):
| RepaintBoundary(renderObject: RenderRepaintBoundary#5401b)>
|    Which: does not match
```