### PR TITLE
Add DanTup/tiler back to registry

### DIFF
--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -2,6 +2,6 @@ contact=danny@tuppeny.com
 fetch=git clone https://github.com/DanTup/tiler.git tests
 fetch=git -C tests checkout 254e93ccfd3a316a562dd3b238a249f985ae0c10
 fetch=git -C tests submodule init
-fetch=git -C tests submodule update --recursive --remote
+fetch=git -C tests submodule update --recursive
 update=.
 test=flutter test test

--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -1,0 +1,7 @@
+contact=danny@tuppeny.com
+fetch=git clone https://github.com/DanTup/tiler.git tests
+fetch=git -C tests checkout 0a5e5e1c01826852ce7fa26fa4abf5e0279689fc
+fetch=git -C tests submodule init
+fetch=git -C tests submodule update --recursive --remote
+update=.
+test=flutter test test

--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -1,6 +1,6 @@
 contact=danny@tuppeny.com
 fetch=git clone https://github.com/DanTup/tiler.git tests
-fetch=git -C tests checkout 0a5e5e1c01826852ce7fa26fa4abf5e0279689fc
+fetch=git -C tests checkout 254e93ccfd3a316a562dd3b238a249f985ae0c10
 fetch=git -C tests submodule init
 fetch=git -C tests submodule update --recursive --remote
 update=.


### PR DESCRIPTION
- Reverts #8 to add Tiler back
- Updates to latest hash
- Removes `--remote` from submodule update which seems to result in getting the latest version rather than the one specified in the parent repo

I don't think these tests are flaky, but rather broke due to a change in Flutter that was then reverted. I'd updated Goldens in the meantime, which resulted in them appearing to break multiple times (and to confuse things, in PRs they could pass/fail based on the Flutter version at the time the branch was made). See more info at https://github.com/flutter/tests/pull/8#issuecomment-513694397.

If we do see them flake again, feel free to drop them and I'll do more investigation though,

@tvolkert @Hixie 