### PR TITLE
Adds instruction to get packages for customer_testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ parallel to your `flutter` repository checkout, then, from this
 directory, run:
 
 ```
-pushd ../flutter/dev/customer_testing/ && pub get && popd
+pushd ../flutter/dev/customer_testing && pub get && popd
 ../flutter/bin/cache/dart-sdk/bin/dart ../flutter/dev/customer_testing/run_tests.dart --skip-template --verbose registry/*.test
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ parallel to your `flutter` repository checkout, then, from this
 directory, run:
 
 ```
+pushd ../flutter/dev/customer_testing/ && pub get && popd
 ../flutter/bin/cache/dart-sdk/bin/dart ../flutter/dev/customer_testing/run_tests.dart --skip-template --verbose registry/*.test
 ```
 
-The first time you run the script, you need to do a `pub get`
-from within the `customer_testing` directory referenced in the
-above command.
+The first command retrieves the Dart packages used by `customer_testing`
+and can be omitted for subsequent executions.
 
 ## If a test is broken
 


### PR DESCRIPTION
It took me a minute to realize the customer_testing folder had its own pubspec that I needed to get packages for. This is a short note to prevent anyone else from getting confused as I did.