### PR TITLE
Add Flutter Gallery with the new repository

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -1,0 +1,6 @@
+contact=raboughanem@google.com
+contact=perc@google.com
+fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
+fetch=git -c core.longPaths=true -C tests checkout c7d23e4eb1b216c551e647634180a2df91e4ed96
+update=.
+test=flutter analyze

--- a/registry/flutter_samples_gallery.test
+++ b/registry/flutter_samples_gallery.test
@@ -1,6 +1,0 @@
-contact=raboughanem@google.com
-fetch=git -c core.longPaths=true clone https://github.com/flutter/samples.git tests
-fetch=git -c core.longPaths=true -C tests checkout 73ee9832a250f6dc33fdc168ca097d7761c5e42a
-fetch=git -c core.longPaths=true -C tests filter-branch --subdirectory-filter gallery
-update=.
-test=flutter analyze

--- a/registry/flutter_samples_gallery.test
+++ b/registry/flutter_samples_gallery.test
@@ -1,6 +1,6 @@
 contact=raboughanem@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/samples.git tests
-fetch=git -c core.longPaths=true -C tests checkout 3a05f1f286c99a99a40c2035fd17488e9b654ba5
+fetch=git -c core.longPaths=true -C tests checkout 73ee9832a250f6dc33fdc168ca097d7761c5e42a
 fetch=git -c core.longPaths=true -C tests filter-branch --subdirectory-filter gallery
 update=.
 test=flutter analyze


### PR DESCRIPTION
I pulled in the https://github.com/flutter/tests/pull/28 into this branch, as we're removing the old location of the gallery and adding the new one here.

Closes https://github.com/material-components/material-components-flutter-gallery/issues/564