### PR TITLE
Shard tests to reduce run time

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,7 @@
 task:
-  name: tests-linux-0
+  name: tests-linux
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 0
-  container:
-    image: gcc:latest
-
-task:
-  name: tests-linux-1
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 1
+  script: scripts/verify_tests_on_master.sh
   container:
     image: gcc:latest
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
     image: gcc:latest
 
 task:
-  name: tests-linux-0
+  name: tests-linux-1
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 1
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,37 @@
 task:
-  name: tests-linux
+  name: tests-linux-0
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  script: scripts/verify_tests_on_master.sh
+  script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 0
   container:
     image: gcc:latest
 
 task:
-  name: tests-windows
+  name: tests-linux-0
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  script: scripts\verify_tests_on_master.bat
+  script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 1
+  container:
+    image: gcc:latest
+
+task:
+  name: tests-windows-0
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  script: scripts\verify_tests_on_master.bat --shards 3 --shard-index 0
+  windows_container:
+    image: cirrusci/windowsservercore:2019
+    os_version: 2019
+
+task:
+  name: tests-windows-1
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  script: scripts\verify_tests_on_master.bat --shards 3 --shard-index 1
+  windows_container:
+    image: cirrusci/windowsservercore:2019
+    os_version: 2019
+
+task:
+  name: tests-windows-2
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  script: scripts\verify_tests_on_master.bat --shards 3 --shard-index 2
   windows_container:
     image: cirrusci/windowsservercore:2019
     os_version: 2019

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -1,6 +1,6 @@
 @ECHO ON
 
-:: Default values.
+REM Default values.
 SET SHARDS=1
 SET SHARD_INDEX=0
 
@@ -8,9 +8,11 @@ REM Parse the arguments for variables.
 :parse
 IF "%1"=="" GOTO endparse
 IF "%1"=="--shards" (
-    SET SHARDS=%2)
+    SET SHARDS=%2
+)
 IF "%1"=="--shard-index" (
-    SET SHARD_INDEX=%2)
+    SET SHARD_INDEX=%2
+)
 
 SHIFT
 GOTO parse

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -1,5 +1,21 @@
 @ECHO ON
 
+:: Default variables.
+SET SHARDS=1
+SET SHARD_INDEX=0
+
+REM Parse the arguments for variables.
+:parse
+IF "%1"=="" GOTO endparse
+IF "%1"=="--shards" (
+    SET SHARDS=%2)
+IF "%1"=="--shard-index" (
+    SET SHARD_INDEX=%2)
+
+SHIFT
+GOTO parse
+:endparse
+
 REM Fetch Flutter.
 git clone https://github.com/flutter/flutter.git || GOTO :END
 CALL flutter\bin\flutter doctor -v || GOTO :END
@@ -18,7 +34,7 @@ CD ..\..\..
 REM Now run the tests a bunch of times to try to find flakes (tests that sometimes pass
 REM even though they should be failing).
 @ECHO.
-CALL dart flutter\dev\customer_testing\run_tests.dart --repeat=15 --skip-template registry/*.test || GOTO :END
+CALL dart flutter\dev\customer_testing\run_tests.dart --repeat=15 --skip-template --shards %SHARDS% --shard-index %SHARD_INDEX% registry/*.test || GOTO :END
 @ECHO ON
 
 @ECHO.

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -1,6 +1,6 @@
 @ECHO ON
 
-:: Default variables.
+:: Default values.
 SET SHARDS=1
 SET SHARD_INDEX=0
 

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -34,7 +34,7 @@ CD ..\..\..
 REM Now run the tests a bunch of times to try to find flakes (tests that sometimes pass
 REM even though they should be failing).
 @ECHO.
-CALL dart flutter\dev\customer_testing\run_tests.dart --repeat=15 --skip-template --shards %SHARDS% --shard-index %SHARD_INDEX% registry/*.test || GOTO :END
+CALL dart flutter\dev\customer_testing\run_tests.dart --repeat=15 --skip-template --shards %SHARDS% --shard-index %SHARD_INDEX% --verbose registry/*.test || GOTO :END
 @ECHO ON
 
 @ECHO.

--- a/scripts/verify_tests_on_master.sh
+++ b/scripts/verify_tests_on_master.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -ex
 
 # Default values.
@@ -24,7 +23,7 @@ esac
 done
 
 # Fetch Flutter.
-#git clone https://github.com/flutter/flutter.git
+git clone https://github.com/flutter/flutter.git
 flutter/bin/flutter doctor -v
 
 export PATH="$PATH":`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin

--- a/scripts/verify_tests_on_master.sh
+++ b/scripts/verify_tests_on_master.sh
@@ -1,7 +1,30 @@
+#!/bin/bash
 set -ex
 
+# Default values.
+SHARDS=1
+SHARD_INDEX=0
+
+# Parse given command for variables.
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    -n|--shards)
+    SHARDS="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -i|--shard-index)
+    SHARD_INDEX="$2"
+    shift # past argument
+    shift # past value
+    ;;
+esac
+done
+
 # Fetch Flutter.
-git clone https://github.com/flutter/flutter.git
+#git clone https://github.com/flutter/flutter.git
 flutter/bin/flutter doctor -v
 
 export PATH="$PATH":`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin
@@ -12,4 +35,4 @@ cd ../../..
 
 # Now run the tests a bunch of times to try to find flakes (tests that sometimes pass
 # even though they should be failing).
-dart flutter/dev/customer_testing/run_tests.dart --repeat=15 --skip-template registry/*.test
+dart flutter/dev/customer_testing/run_tests.dart --shards $SHARDS --shard-index $SHARD_INDEX --repeat=15 --skip-template --verbose registry/*.test


### PR DESCRIPTION
Follow up from https://github.com/flutter/flutter/pull/53433, implementing the sharding flags in this repo's CI.

This unblocks tests from being added to this repo as windows tests currently take ~55 minutes to finish, and the timeout is at 60 minutes. This prevents new windows tests from being added.

I have sharded the tests to bring them all under 30 minutes by splitting windows into 3 shards. We can get linux to under 15 minutes by splitting into two, but because Windows is the bottleneck, only windows is sharded.