### PR TITLE
remove flutter boost regstry due to inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ these tests to fail, you have the following options:
    solution. To go down this path, we must first establish that one of
    the following is true:
 
-    - the people listed as contacts for the test are not responsive.
+    - the people listed as contacts for the test are not responsive (within 72 hours).
 
     - the test is poorly written (e.g. it contains a race condition or
       relies on assumptions that violate clearly documented API

--- a/registry/flutter_boost.test
+++ b/registry/flutter_boost.test
@@ -1,6 +1,0 @@
-contact=noborder@qq.com
-fetch=git clone https://github.com/alibaba/flutter_boost.git tests
-fetch=git -C tests checkout 4aa4a9ec69cf912075083d695a55313ee06bb38e
-update=.
-# test=flutter analyze
-test=flutter test

--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -1,6 +1,6 @@
 contact=raboughanem@google.com
 contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
-fetch=git -c core.longPaths=true -C tests checkout b22eb190a66a5fb61fcafcc5fa66723f37e17723
+fetch=git -c core.longPaths=true -C tests checkout e6357bccc49ec542ca127ca4b26b2b87216d07d5
 update=.
 test=flutter analyze


### PR DESCRIPTION
I have not been able to reach the maintainer of flutter boost through github or email contact.
https://github.com/alibaba/flutter_boost/issues/780

This is blocking the change to be landed https://github.com/flutter/flutter/pull/60655
with migration guide https://github.com/flutter/website/pull/4350/files



related: https://github.com/flutter/flutter/issues/45938