### PR TITLE
remove cocoon test

### DIFF
--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -1,7 +1,0 @@
-contact=flutter-infra@google.com
-fetch=git clone https://github.com/flutter/cocoon.git tests
-fetch=git -C tests checkout 48c41ad09295fcde7074e1f24b64ea53e61f0920
-update=.
-# Runs flutter analyze, flutter test, and builds web platform
-test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
-test.windows=.\test_utilities\bin\flutter_test_runner.bat app_flutter


### PR DESCRIPTION
Because Cocoon CI runs on stable flutter SDK, breaking changes will lead to a state where `customer_testing` on the framework CI and cocoon CI cannot both pass at the same time.

Remove cocoon from flutter/tests until https://github.com/flutter/flutter/issues/65045 is resolved. I believe the only way to re-enable cocoon here would be if we run Cocoon CI with latest Flutter SDK (and then we'd have to land the change to unblock `customer_testing` on red cocoon CI, but Cocoon CI should go green on the NEXT change).