### PR TITLE
Update tests after ScaffoldMessenger Migration

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -1,6 +1,6 @@
 contact=raboughanem@google.com
 contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
-fetch=git -c core.longPaths=true -C tests checkout eafeae1339349decd649fcf80859c49f5936fd07
+fetch=git -c core.longPaths=true -C tests checkout 17437dee5cdef57cbedaa5a5cc6c8105464ec4bf
 update=.
 test=flutter analyze

--- a/registry/flutter_packages.test
+++ b/registry/flutter_packages.test
@@ -2,7 +2,7 @@
 
 contact=goderbauer@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/packages.git tests
-fetch=git -c core.longPaths=true -C tests checkout 2d1e3968a6b9efe4ceabbae5adbe80aa1c1cf63b
+fetch=git -c core.longPaths=true -C tests checkout c2c4b3329353c4db94f32dfc3a0d32bdbffd8ffe
 update=.
 test.windows=.\customer_testing.bat
 test.posix=./customer_testing.sh

--- a/registry/rainbowmonkey.test
+++ b/registry/rainbowmonkey.test
@@ -3,7 +3,7 @@
 
 contact=ian@hixie.ch
 fetch=git clone https://github.com/seamonkeysocial/rainbowmonkey.git tests
-fetch=git -C tests checkout c808dee61cddd7245b17530b882eb48769bc9d74
+fetch=git -C tests checkout d71e04b6f4b2e833b9d047489cf1b7a94eeadb1f
 update=.
 test=flutter analyze
 test=flutter test


### PR DESCRIPTION
This updates the commits for three apps that have been migrated to ScaffoldMessenger.

Breaking Change:
https://github.com/flutter/flutter/pull/67947

Migrations for each:
https://github.com/flutter/gallery/pull/343
https://github.com/flutter/packages/pull/223
https://github.com/jocosocial/rainbowmonkey/pull/330