### PR TITLE
Temporarily delete Gallery test

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -1,6 +1,0 @@
-contact=raboughanem@google.com
-contact=perc@google.com
-fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
-fetch=git -c core.longPaths=true -C tests checkout 0423ac456c40a913a9750844e6ed9fa2c9a3a45e
-update=.
-test=flutter analyze


### PR DESCRIPTION
Unfortunately, the Flutter gallery depends on packages that aren't migrated to null safety and conflict with the null safety version of `intl` if set in the framework.

The packages are: `intl_translation`, `flutter_localized_locales`. 

If you have a suggestion on how to workaround this issue without temporarily disabling the test, please let me know. I'm happy to delete this PR if there's a better way to go about it.
