### PR TITLE
Add test for package assorted_layout_widgets

### DIFF
--- a/registry/assorted_layout_widgets.test
+++ b/registry/assorted_layout_widgets.test
@@ -1,0 +1,8 @@
+contact=marcglasberg@gmail.com
+contact=pascal@pascalwelsch.com
+
+fetch=git clone https://github.com/marcglasberg/assorted_layout_widgets.git tests
+fetch=git -C tests checkout 388db9ea38df1e0991ffdbe8e790699fb089202a
+update=.
+test=flutter test
+


### PR DESCRIPTION
The [`assorted_layout_widgets`](https://github.com/marcglasberg/assorted_layout_widgets) package had already to deal with [breaking](https://github.com/marcglasberg/assorted_layout_widgets/pull/2) [changes](https://github.com/marcglasberg/assorted_layout_widgets/pull/7) in the past.

//cc @marcglasberg
