### PR TITLE
Update readme: test repos must use latest Flutter on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Tests must fulfill the following criteria to be added:
 
 * The tests must pass at the time they are contributed.
 
+* The upstream repository that hosts the tests must be able to receive patches
+  to support the `master` channel of Flutter. This means that CI on the
+  upstream repository should use the `master` channel Flutter SDK.
+
 * Dependencies must be pinned. (Generally, checking in the
   `pubspec.lock` file is sufficient for this purpose.)
 


### PR DESCRIPTION
Per chat discussion, clarify in README that test repos must accept patches to support `master` channel Flutter SDK.