### PR TITLE
Re-add flutter/cocoon to customer_testing

### DIFF
--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -5,5 +5,4 @@ update=.
 # Runs flutter analyze, flutter test, and builds web platform
 test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
 test.posix=./test_utilities/bin/flutter_test_runner.sh repo_dashboard
-test.windows=.\test_utilities\bin\flutter_test_runner.bat app_flutter
 test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dashboard

--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -4,4 +4,6 @@ fetch=git -C tests checkout d80254e5f6a62df6e19db1ed857597c7732ebca1
 update=.
 # Runs flutter analyze, flutter test, and builds web platform
 test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
+test.posix=./test_utilities/bin/flutter_test_runner.sh repo_dash
 test.windows=.\test_utilities\bin\flutter_test_runner.bat app_flutter
+test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dash

--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -1,6 +1,6 @@
 contact=flutter-infra@google.com
 fetch=git clone https://github.com/flutter/cocoon.git tests
-fetch=git -C tests checkout d80254e5f6a62df6e19db1ed857597c7732ebca1
+fetch=git -C tests checkout 6ddf28856681ff2c608dfda62b037bdb81f55dc5
 update=.
 # Runs flutter analyze, flutter test, and builds web platform
 test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter

--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -1,0 +1,7 @@
+contact=flutter-infra@google.com
+fetch=git clone https://github.com/flutter/cocoon.git tests
+fetch=git -C tests checkout d80254e5f6a62df6e19db1ed857597c7732ebca1
+update=.
+# Runs flutter analyze, flutter test, and builds web platform
+test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
+test.windows=.\test_utilities\bin\flutter_test_runner.bat app_flutter

--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -4,6 +4,6 @@ fetch=git -C tests checkout d80254e5f6a62df6e19db1ed857597c7732ebca1
 update=.
 # Runs flutter analyze, flutter test, and builds web platform
 test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
-test.posix=./test_utilities/bin/flutter_test_runner.sh repo_dash
+test.posix=./test_utilities/bin/flutter_test_runner.sh repo_dashboard
 test.windows=.\test_utilities\bin\flutter_test_runner.bat app_flutter
-test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dash
+test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dashboard


### PR DESCRIPTION
flutter/cocoon now runs CI on Flutter master. The original issue was the repo used the same Flutter channel for both tests and releases. We have left AppEngine deployments on the beta channel for stability, which does not impact customer_testing.

This adds back the flutter dashboard app, and newly adds the repo dashboard app (previously on the Flutter web fork). 

# Issues

Closes https://github.com/flutter/flutter/issues/65045