### PR TITLE
Update flutter_svg.test (#68)

### DIFF
--- a/registry/flutter_svg.test
+++ b/registry/flutter_svg.test
@@ -1,6 +1,6 @@
 contact=dfield@gmail.com
 fetch=git clone https://github.com/dnfield/flutter_svg.git tests
-fetch=git -C tests checkout 27caeea46ac14d6d6f9e0329a1f094addd61eb34
+fetch=git -C tests checkout 1a6e8706696e96edead88bf2d67ebb65582512cb
 update=.
 # test=flutter analyze # as of 2020-02-15, analysis failed, so we couldn't enable this
 test=flutter test


### PR DESCRIPTION
To capture latest changes for Skia roll.

This is required to roll the engine to latest. This is a re-land of #68 which
was reverted in #69 due to an unrelated issue in the same engine roll.