### PR TITLE
Revert "Temporarily remove flutter/cocoon"

### DIFF
--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -1,0 +1,8 @@
+contact=flutter-infra@google.com
+fetch=git clone https://github.com/flutter/cocoon.git tests
+fetch=git -C tests checkout f6ebba23b5815ce958a2ef099ef3e3cbd8e318cd
+update=.
+# Runs flutter analyze, flutter test, and builds web platform
+test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
+test.posix=./test_utilities/bin/flutter_test_runner.sh repo_dashboard
+test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dashboard

--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -1,6 +1,6 @@
 contact=flutter-infra@google.com
 fetch=git clone https://github.com/flutter/cocoon.git tests
-fetch=git -C tests checkout f6ebba23b5815ce958a2ef099ef3e3cbd8e318cd
+fetch=git -C tests checkout 5dc667795520265c7796050fa2365e262276ed1a
 update=.
 # Runs flutter analyze, flutter test, and builds web platform
 test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter


### PR DESCRIPTION
Reverts flutter/tests#79

Cocoon has been rebaselined now so we can re-enable these tests.