### PR TITLE
Updated flutter_gallery and rainbowmonkey repo commit hashes

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -3,6 +3,6 @@ contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
 # If you bump this here, you may also want to bump it for the devicelab tests, at:
 # dev/devicelab/lib/versions/gallery.dart in the flutter repo.
-fetch=git -c core.longPaths=true -C tests checkout e06144fe0c2084d5f9d0c90a070f33009a497af1
+fetch=git -c core.longPaths=true -C tests checkout 8d47b95ef47fc18753f1d99dfcbf0e6b027c662d
 update=.
 test=flutter analyze

--- a/registry/rainbowmonkey.test
+++ b/registry/rainbowmonkey.test
@@ -3,7 +3,7 @@
 
 contact=ian@hixie.ch
 fetch=git clone https://github.com/seamonkeysocial/rainbowmonkey.git tests
-fetch=git -C tests checkout 99f5ec248f95972cc35eaafb2ca5556833974f50
+fetch=git -C tests checkout b62c5d40a57f3aa3bed520125e8b9f31a2453e8e
 update=.
 test=flutter analyze
 test=flutter test


### PR DESCRIPTION
Update the flutter_gallery and rainbowmonkey repo commit hashes to bring in changes related to https://github.com/flutter/flutter/pull/81336.

