### PR TITLE
Updated registry/flutter_gallery.test

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -3,6 +3,6 @@ contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
 # If you bump this here, you may also want to bump it for the devicelab tests, at:
 # dev/devicelab/lib/versions/gallery.dart in the flutter repo.
-fetch=git -c core.longPaths=true -C tests checkout a9b8d6c8875342d936c80247a7420a3a4d7cabb9
+fetch=git -c core.longPaths=true -C tests checkout e44cd514e155f99dedbd10833063170d7de35ffb
 update=.
 test=flutter analyze


### PR DESCRIPTION
Updated for https://github.com/flutter/gallery/pull/497 which enables https://github.com/flutter/flutter/pull/82196 to land.