### PR TITLE
update calls to 'flutter analyze' to pass --no-fatal-infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Tests must fulfill the following criteria to be added:
   package by casting it to dynamic is similarly sketchy and would not
   be supported behaviour.
 
+* The tests must pass even if there are analysis 'info' level issues in the code.
+  Generally, this means that if the test performs static analysis, it does so
+  ignoring info level items (i.e., `flutter analyze --no-fatal-infos`).
+
 * The tests must pass at the time they are contributed.
 
 * The upstream repository that hosts the tests must be able to receive patches

--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -4,5 +4,5 @@ fetch=git -C tests checkout 44b41536e7428d1070e8e2bd91376132c5a484fc
 fetch=git -C tests submodule init
 fetch=git -C tests submodule update --recursive
 update=.
-# test=flutter analyze # as of 2020-02-15, analysis failed, so we couldn't enable this
+# test=flutter analyze --no-fatal-infos # as of 2020-02-15, analysis failed, so we couldn't enable this
 test=flutter test test

--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -5,4 +5,4 @@ fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git te
 # dev/devicelab/lib/versions/gallery.dart in the flutter repo.
 fetch=git -c core.longPaths=true -C tests checkout e44cd514e155f99dedbd10833063170d7de35ffb
 update=.
-test=flutter analyze
+test=flutter analyze --no-fatal-infos

--- a/registry/flutter_reactive_ble.test
+++ b/registry/flutter_reactive_ble.test
@@ -3,5 +3,5 @@ fetch=git -c core.longPaths=true clone https://github.com/PhilipsHue/flutter_rea
 fetch=git -c core.longPaths=true -C tests checkout 3e70254fdf5aa348b4d2d93c8ef7d4f490a5237a
 update=.
 test=flutter packages get
-test=flutter analyze
+test=flutter analyze --no-fatal-infos
 test=flutter test

--- a/registry/flutter_svg.test
+++ b/registry/flutter_svg.test
@@ -2,5 +2,5 @@ contact=dfield@gmail.com
 fetch=git clone https://github.com/dnfield/flutter_svg.git tests
 fetch=git -C tests checkout af7963b03679de2fbf2855e76a1802e9ead8afc5
 update=.
-test=flutter analyze
+test=flutter analyze --no-fatal-infos
 test=flutter test

--- a/registry/provider.test
+++ b/registry/provider.test
@@ -2,5 +2,5 @@ contact=darky12s@gmail.com
 fetch=git clone https://github.com/rrousselGit/provider.git tests
 fetch=git -C tests checkout faa2d4fd97a5d95345c95525250cb0ed2602003b
 update=.
-# test=flutter analyze # as of 2020-02-15, analysis failed
+# test=flutter analyze --no-fatal-infos # as of 2020-02-15, analysis failed
 test=flutter test

--- a/registry/rainbowmonkey.test
+++ b/registry/rainbowmonkey.test
@@ -5,5 +5,5 @@ contact=ian@hixie.ch
 fetch=git clone https://github.com/seamonkeysocial/rainbowmonkey.git tests
 fetch=git -C tests checkout dbd15caff8ae77ee729023e6e7ea312307952226
 update=.
-test=flutter analyze
+test=flutter analyze --no-fatal-infos
 test=flutter test

--- a/registry/template.test
+++ b/registry/template.test
@@ -119,7 +119,7 @@ update=.
 #
 # You are encouraged to also use "flutter analyze" to catch problems
 # that affect code that isn't tested.
-test=flutter analyze
+test=flutter analyze --no-fatal-infos
 test=flutter test
 test=more_tests
 test=dart dev/extra_tests.dart


### PR DESCRIPTION
- update calls to 'flutter analyze' to pass --no-fatal-infos

This PR updates calls to `flutter analyze` to pass in the `--no-fatal-infos` command line flag, as well as updates the test guidance in the readme file.

There are a few other tests (https://github.com/flutter/tests/blob/master/registry/flutter_cocoon.test; https://github.com/flutter/tests/blob/master/registry/flutter_packages.test) that we may also want to update to do the same thing, but that will take upstream work in those repos first, in order to make their tests parameterizable. 

More context for this change is available at https://github.com/dart-lang/sdk/issues/46075. Generally, the intent of these tests is to help know when Flutter API changes will break customers. Testing for 'error' level items do that, and to some extent 'warning' level items as well; testing for the 'info' level items presents a larger than desired barrier to making changes and fixes to Dart's static analysis.
