### PR TITLE
Update commit hash for flutter gallery

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -3,6 +3,6 @@ contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
 # If you bump this here, you may also want to bump it for the devicelab tests, at:
 # dev/devicelab/lib/versions/gallery.dart in the flutter repo.
-fetch=git -c core.longPaths=true -C tests checkout 0ea2ff674689fea7342278d4975e03498ec114a0
+fetch=git -c core.longPaths=true -C tests checkout 07e72e69c376ce27f635793323340b5af8bb2e58
 update=.
 test=flutter analyze --no-fatal-infos

--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -3,6 +3,6 @@ contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
 # If you bump this here, you may also want to bump it for the devicelab tests, at:
 # dev/devicelab/lib/versions/gallery.dart in the flutter repo.
-fetch=git -c core.longPaths=true -C tests checkout 07e72e69c376ce27f635793323340b5af8bb2e58
+fetch=git -c core.longPaths=true -C tests checkout 8803fd59b8cd566c96ad42febafa39133faf44f6
 update=.
 test=flutter analyze --no-fatal-infos

--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -3,6 +3,6 @@ contact=perc@google.com
 fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
 # If you bump this here, you may also want to bump it for the devicelab tests, at:
 # dev/devicelab/lib/versions/gallery.dart in the flutter repo.
-fetch=git -c core.longPaths=true -C tests checkout 426287b33df1b45168737779a6d0f23e73666be2
+fetch=git -c core.longPaths=true -C tests checkout 0ea2ff674689fea7342278d4975e03498ec114a0
 update=.
 test=flutter analyze --no-fatal-infos


### PR DESCRIPTION
Latest version of the Gallery includes [a fix](https://github.com/flutter/gallery/commit/38f9d660b9fe9b926c617fa8ada5a5b9a29bce39#diff-b7de41cdbcba9a9b424e1089f915fc8c18c9acedcce154d332501b33bd71f458R209-R210) which is required to make https://github.com/flutter/flutter/pull/100427 tests pass.
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
