### PR TITLE
Roll the flutter_packages tests

### DIFF
--- a/registry/flutter_packages.test
+++ b/registry/flutter_packages.test
@@ -9,6 +9,6 @@ contact=ian@hixie.ch
 update=packages/rfw
 
 fetch=git -c core.longPaths=true clone https://github.com/flutter/packages.git tests
-fetch=git -c core.longPaths=true -C tests checkout 8b5929c55bf7206a8da1a8df750598210498af11
+fetch=git -c core.longPaths=true -C tests checkout 2c02052ce8ba83edee76fef41a2475edab824c17
 test.windows=.\customer_testing.bat
 test.posix=./customer_testing.sh


### PR DESCRIPTION
Required due to the deprecation of hashValues in the engine
(see https://github.com/flutter/flutter/pull/105038)
