### PR TITLE
Add super editor tests

### DIFF
--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -13,14 +13,8 @@ fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout 80c79b33e0d7ce5bb148e1731f9aae34042217ab
 
 # Run the tests.
-test.posix=./flutter_test_repo_attributed_text_test.sh
-test.windows=.\flutter_test_repo_attributed_text_test.bat
-
-test.posix=./flutter_test_repo_super_text_layout_test.sh
-test.windows=.\flutter_test_repo_super_text_layout_test.bat
-
-test.posix=./flutter_test_repo_super_editor_test.sh
-test.windows=.\flutter_test_repo_super_editor_test.bat
+test.posix=./flutter_test_registry/flutter_test_repo_test.sh
+test.windows=.\flutter_test_registry\flutter_test_repo_test.bat
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -4,23 +4,23 @@
 contact=flutterbountyhunters@gmail.com
 
 # Update
-update=./attributed_text/
-update=./super_text_layout/
-update=./super_editor/
+update=attributed_text/
+update=super_text_layout/
+update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout 004a6b93a56f18ec5320d340f61f8158febd59f8
 
 # Run the tests.
-test.posix=./flutter_test_repo_attributed_text_test.sh
-test.windows=.\flutter_test_repo_attributed_text_test.bat
+test.posix=flutter_test_repo_attributed_text_test.sh
+test.windows=flutter_test_repo_attributed_text_test.bat
 
-test.posix=./flutter_test_repo_super_text_layout_test.sh
-test.windows=.\flutter_test_repo_super_text_layout_test.bat
+test.posix=flutter_test_repo_super_text_layout_test.sh
+test.windows=flutter_test_repo_super_text_layout_test.bat
 
-test.posix=./flutter_test_repo_super_editor_test.sh
-test.windows=.\flutter_test_repo_super_editor_test.bat
+test.posix=flutter_test_repo_super_editor_test.sh
+test.windows=flutter_test_repo_super_editor_test.bat
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -1,0 +1,31 @@
+# Tests for the super_editor mono repo.
+
+# Contacts
+contact=flutterbountyhunters@gmail.com
+
+# Update
+update=./attributed_text/
+update=./super_text_layout/
+update=./super_editor/
+
+# Fetch the super_editor mono repo
+fetch=git clone https://github.com/superlistapp/super_editor.git tests
+fetch=git -C tests checkout 504093e82e44be4547958559ffc26aa48f08fa0c
+
+# Run the tests using a single script at the root of the mono repo.
+test=./run_flutter_test_repository_tests
+
+# To test your tests, check out the flutter/flutter repository and
+# then, from the root of that repository, run:
+#
+#   bin/flutter; cd dev/customer_testing; flutter pub get; time ../../bin/cache/dart-sdk/bin/dart run_tests.dart --repeat=100 <path>
+#
+# ...where <path> is the path to this file.
+#
+# This should run with no output, without failing, and should in total
+# take less than 15 minutes (a hundred runs of your tests taking just
+# a few seconds each). If your tests take longer, mention this in your
+# PR and we will evaluate them to see how valuable they are (e.g. how
+# unique and different they are compared to other tests we already
+# have). The more valuable the tests, the more likely we are to accept
+# them despite them taking a long time to run.

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -13,9 +13,14 @@ fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout a81e83c64683390a1d83a0979c88b5a09beab82e
 
 # Run the tests.
-test=flutter_test_repo_attributed_text_test
-test=flutter_test_repo_super_text_layout_test
-test=flutter_test_repo_super_editor_test
+test.posix=./flutter_test_repo_attributed_text_test
+test.windows=.\flutter_test_repo_attributed_text_test
+
+test.posix=./flutter_test_repo_super_text_layout_test
+test.windows=.\flutter_test_repo_super_text_layout_test
+
+test.posix=./flutter_test_repo_super_editor_test
+test.windows=.\flutter_test_repo_super_editor_test
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout edeb6be55b198934631580d0cc9c4b96a8092c70
+fetch=git -C tests checkout b429a710ea35eb7037c9ef59d40990d7b3851645
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -8,11 +8,11 @@ update=./attributed_text/
 update=./super_text_layout/
 update=./super_editor/
 
-# Fetch the super_editor mono repo
+# Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout c99cad7f0b130b700998ac9bd2d5e9cb650a4da8
 
-# Run the tests using a single script at the root of the mono repo.
+# Run the tests.
 test=./flutter_test_repo_attributed_text_test
 test=./flutter_test_repo_super_text_layout_test
 test=./flutter_test_repo_super_editor_test

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=./super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout c99cad7f0b130b700998ac9bd2d5e9cb650a4da8
+fetch=git -C tests checkout a81e83c64683390a1d83a0979c88b5a09beab82e
 
 # Run the tests.
 test=./flutter_test_repo_attributed_text_test

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -13,14 +13,14 @@ fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout 004a6b93a56f18ec5320d340f61f8158febd59f8
 
 # Run the tests.
-test.posix=flutter_test_repo_attributed_text_test.sh
-test.windows=flutter_test_repo_attributed_text_test.bat
+test.posix=./flutter_test_repo_attributed_text_test.sh
+test.windows=.\flutter_test_repo_attributed_text_test.bat
 
-test.posix=flutter_test_repo_super_text_layout_test.sh
-test.windows=flutter_test_repo_super_text_layout_test.bat
+test.posix=./flutter_test_repo_super_text_layout_test.sh
+test.windows=.\flutter_test_repo_super_text_layout_test.bat
 
-test.posix=flutter_test_repo_super_editor_test.sh
-test.windows=flutter_test_repo_super_editor_test.bat
+test.posix=./flutter_test_repo_super_editor_test.sh
+test.windows=.\flutter_test_repo_super_editor_test.bat
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout b429a710ea35eb7037c9ef59d40990d7b3851645
+fetch=git -C tests checkout d29713d22f4d38122475abf94bf534a156278864
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout d29713d22f4d38122475abf94bf534a156278864
+fetch=git -C tests checkout bb3b49d852ef189fb25137129b52145c089bb83a
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout 80c79b33e0d7ce5bb148e1731f9aae34042217ab
+fetch=git -C tests checkout edeb6be55b198934631580d0cc9c4b96a8092c70
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -13,9 +13,9 @@ fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout a81e83c64683390a1d83a0979c88b5a09beab82e
 
 # Run the tests.
-test=./flutter_test_repo_attributed_text_test
-test=./flutter_test_repo_super_text_layout_test
-test=./flutter_test_repo_super_editor_test
+test=flutter_test_repo_attributed_text_test
+test=flutter_test_repo_super_text_layout_test
+test=flutter_test_repo_super_editor_test
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,10 +10,12 @@ update=./super_editor/
 
 # Fetch the super_editor mono repo
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout 504093e82e44be4547958559ffc26aa48f08fa0c
+fetch=git -C tests checkout c99cad7f0b130b700998ac9bd2d5e9cb650a4da8
 
 # Run the tests using a single script at the root of the mono repo.
-test=./run_flutter_test_repository_tests
+test=./flutter_test_repo_attributed_text_test
+test=./flutter_test_repo_super_text_layout_test
+test=./flutter_test_repo_super_editor_test
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout febe7e5200a942cfc90e607e2ddb1077348f4a2b
+fetch=git -C tests checkout 80c79b33e0d7ce5bb148e1731f9aae34042217ab
 
 # Run the tests.
 test.posix=./flutter_test_repo_attributed_text_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout 004a6b93a56f18ec5320d340f61f8158febd59f8
+fetch=git -C tests checkout febe7e5200a942cfc90e607e2ddb1077348f4a2b
 
 # Run the tests.
 test.posix=./flutter_test_repo_attributed_text_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,17 +10,17 @@ update=./super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout a81e83c64683390a1d83a0979c88b5a09beab82e
+fetch=git -C tests checkout 004a6b93a56f18ec5320d340f61f8158febd59f8
 
 # Run the tests.
-test.posix=./flutter_test_repo_attributed_text_test
-test.windows=.\flutter_test_repo_attributed_text_test
+test.posix=./flutter_test_repo_attributed_text_test.sh
+test.windows=.\flutter_test_repo_attributed_text_test.bat
 
-test.posix=./flutter_test_repo_super_text_layout_test
-test.windows=.\flutter_test_repo_super_text_layout_test
+test.posix=./flutter_test_repo_super_text_layout_test.sh
+test.windows=.\flutter_test_repo_super_text_layout_test.bat
 
-test.posix=./flutter_test_repo_super_editor_test
-test.windows=.\flutter_test_repo_super_editor_test
+test.posix=./flutter_test_repo_super_editor_test.sh
+test.windows=.\flutter_test_repo_super_editor_test.bat
 
 # To test your tests, check out the flutter/flutter repository and
 # then, from the root of that repository, run:


### PR DESCRIPTION
This PR adds the `super_editor` mono repo to the test registry.

`super_editor` is here:
https://github.com/superlistapp/super_editor

I wanted to define all the tests in a single script, but I couldn't get it to work:

- First, I tried placing all test commands in a single file. When I ran that locally, it hung forever without any output. When I tried that in CI, it failed for some reason.
- I gave up and divided that file into a different script for every project in the repo. That failed because Windows didn't recognize the script file without an extension. So then I was forced to separate `.sh` from `.bat` and configure per-platform.

We now have a regrettable number of scripts in our super_editor repo to integrate with this test repo. I'd like to reduce these scripts down to one, if possible.