### PR TITLE
Add flutter/cocoon to flutter/tests

### DIFF
--- a/registry/flutter_cocoon.test
+++ b/registry/flutter_cocoon.test
@@ -1,0 +1,7 @@
+contact=flutter-infra@google.com
+fetch=git clone https://github.com/flutter/cocoon.git tests
+fetch=git -C tests checkout b5f4a23ed535ce4fed77e3c1124643e0838f6fdc
+update=dashboard
+# Runs flutter analyze, flutter test, and builds web platform
+test.posix=./test_utilities/bin/flutter_test_runner.sh dashboard
+


### PR DESCRIPTION
This would have caught b/242043014 since Cocoon builds dart generated protos