### PR TITLE
Reduce number of test repeats on windows

### DIFF
--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -41,8 +41,10 @@ CD ..\..\..
 
 :: Now run the tests a bunch of times to try to find flakes (tests that sometimes pass
 :: even though they should be failing).
+:: Windows takes longer than the other systems to run tests. Default is lowered
+:: to 10 repeat runs to reduce strain on infra.
 @ECHO.
-CALL dart flutter\dev\customer_testing\run_tests.dart --repeat=15 --skip-template --shards %SHARDS% --shard-index %SHARD_INDEX% --verbose registry/*.test || GOTO :END
+CALL dart flutter\dev\customer_testing\run_tests.dart --repeat=10 --skip-template --shards %SHARDS% --shard-index %SHARD_INDEX% --verbose registry/*.test || GOTO :END
 @ECHO ON
 
 @ECHO.


### PR DESCRIPTION
My PR in https://github.com/flutter/tests/pull/141 is blocked as one of the shards is timing out. It looks like one of the tests in that shard is very large.

Instead of adding a new shard, I think reducing the number of runs on windows is the right move (as we still get the flake checking on linux and mac).