### PR TITLE
Add Super Editor back to test registry

### DIFF
--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -1,0 +1,32 @@
+# Tests for the super_editor mono repo.
+
+# Contacts
+contact=flutterbountyhunters@gmail.com
+
+# Update
+update=attributed_text/
+update=super_text_layout/
+update=super_editor/
+
+# Fetch the super_editor mono repo.
+fetch=git clone https://github.com/superlistapp/super_editor.git tests
+fetch=git -C tests checkout db9be850fcc51c7308e1fef78cc71d76b4c106db
+
+# Run the tests.
+test.posix=./flutter_test_registry/flutter_test_repo_test.sh
+test.windows=.\flutter_test_registry\flutter_test_repo_test.bat
+
+# To test your tests, check out the flutter/flutter repository and
+# then, from the root of that repository, run:
+#
+#   bin/flutter; cd dev/customer_testing; flutter pub get; time ../../bin/cache/dart-sdk/bin/dart run_tests.dart --repeat=100 <path>
+#
+# ...where <path> is the path to this file.
+#
+# This should run with no output, without failing, and should in total
+# take less than 15 minutes (a hundred runs of your tests taking just
+# a few seconds each). If your tests take longer, mention this in your
+# PR and we will evaluate them to see how valuable they are (e.g. how
+# unique and different they are compared to other tests we already
+# have). The more valuable the tests, the more likely we are to accept
+# them despite them taking a long time to run.

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout db9be850fcc51c7308e1fef78cc71d76b4c106db
+fetch=git -C tests checkout 742283787ec03fc6d0e98ee82dc0ed6c508dc32d
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -10,7 +10,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout 742283787ec03fc6d0e98ee82dc0ed6c508dc32d
+fetch=git -C tests checkout bc121ccefcb40fd9dd1517784b89c6786be843d0
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh


### PR DESCRIPTION
Super Editor was removed from the test registry for not keeping up with Flutter's breaking changes.

This PR adds Super Editor back to the test registry after adjusting to the latest breaking changes.