### PR TITLE
Revert "Remove tiler from customer test suite"

### DIFF
--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -6,7 +6,7 @@
 
 contact=danny@tuppeny.com
 fetch=git clone https://github.com/DanTup/tiler.git tests
-fetch=git -C tests checkout b9f524fb1cb4d066454bf3ee2a086034a15c850e
+fetch=git -C tests checkout 9127a917ae297f31eb2cf495b82924438f6c62d5
 fetch=git -C tests submodule init
 fetch=git -C tests submodule update --recursive
 update=.

--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -1,0 +1,14 @@
+# This project isn't being actively maintained by Danny any more, so
+# if we end up in a situation where we need a major refactor or some
+# such, then it's ok to just remove this entry. That said, do prefer
+# to fix things when you can if it's possible, PRs do this repo do
+# still get accepted.
+
+contact=danny@tuppeny.com
+fetch=git clone https://github.com/DanTup/tiler.git tests
+fetch=git -C tests checkout b9f524fb1cb4d066454bf3ee2a086034a15c850e
+fetch=git -C tests submodule init
+fetch=git -C tests submodule update --recursive
+update=.
+test=flutter analyze --no-fatal-infos
+test=flutter test test


### PR DESCRIPTION
Reverts flutter/tests#179

The tiler repo has been migrated to null-safety at tip-of-tree. Additionally, I had misunderstood our test repo policy. As long as the maintainer is still accepting PRs, we should not be deleting tests. This is true even if the pub package for the repo has been discontinued. See the discussion on flutter/tests#179.

This PR reverts the deletion, and rolls forward to tiler tip-of-tree.
