### PR TITLE
Add id-token write permission required by scorecard action

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      id-token: write
       actions: read
       contents: read
 


### PR DESCRIPTION
Adds the `id-token: write` permission as required by [ossf/scorecard-action v2](https://github.com/ossf/scorecard-action#breaking-changes-in-v2).
