### PR TITLE
Bump tiler for separate M1 macOS goldens + update Cirrus to use M1 Macs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,14 +41,14 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 0
   osx_instance:
-    image: mojave-base
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:14
 
 task:
   name: tests-macos-1
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 1
   osx_instance:
-    image: mojave-base
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:14
 
 task:
   name: skp_generator

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,14 +41,14 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 0
   osx_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.2
 
 task:
   name: tests-macos-1
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 1
   osx_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.2
 
 task:
   name: skp_generator

--- a/registry/DanTup_tiler.test
+++ b/registry/DanTup_tiler.test
@@ -6,7 +6,7 @@
 
 contact=danny@tuppeny.com
 fetch=git clone https://github.com/DanTup/tiler.git tests
-fetch=git -C tests checkout 570364385b43c84b20a1d46b87344f3c9ae08aab
+fetch=git -C tests checkout 3cb0cad96cc393b85cf7e38c4623cc16390f906e
 fetch=git -C tests submodule init
 fetch=git -C tests submodule update --recursive
 update=.

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -29,7 +29,9 @@ git clone https://github.com/flutter/flutter.git || GOTO :END
 CALL flutter\bin\flutter doctor -v || GOTO :END
 @ECHO ON
 
-SET PATH=%PATH%;%CD%\flutter/bin;%CD%\flutter\bin\cache\dart-sdk\bin
+# Put Flutter at the start of the PATH because the OS image may contain
+# another version of Flutter.
+SET PATH=%CD%\flutter/bin;%CD%\flutter\bin\cache\dart-sdk\bin;%PATH%
 
 @ECHO.
 @ECHO.

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -24,14 +24,11 @@ certutil -syncwithWU C:\Certs
 powershell.exe -c "Get-ChildItem -Path C:\certs -Filter '*.crt' | foreach-object {certutil -addstore -f root $_.fullname; $_.fullname}"
 rmdir c:\certs /s /q
 
-:: Fetch Flutter.
-git clone https://github.com/flutter/flutter.git || GOTO :END
-CALL flutter\bin\flutter doctor -v || GOTO :END
+:: Switch to Flutter master.
+flutter channel master || GOTO :END
+flutter upgrade || GOTO :END
+flutter doctor -v || GOTO :END
 @ECHO ON
-
-# Put Flutter at the start of the PATH because the OS image may contain
-# another version of Flutter.
-SET PATH=%CD%\flutter/bin;%CD%\flutter\bin\cache\dart-sdk\bin;%PATH%
 
 @ECHO.
 @ECHO.

--- a/scripts/verify_tests_on_master.bat
+++ b/scripts/verify_tests_on_master.bat
@@ -24,11 +24,14 @@ certutil -syncwithWU C:\Certs
 powershell.exe -c "Get-ChildItem -Path C:\certs -Filter '*.crt' | foreach-object {certutil -addstore -f root $_.fullname; $_.fullname}"
 rmdir c:\certs /s /q
 
-:: Switch to Flutter master.
-flutter channel master || GOTO :END
-flutter upgrade || GOTO :END
-flutter doctor -v || GOTO :END
+:: Fetch Flutter.
+git clone https://github.com/flutter/flutter.git || GOTO :END
+CALL flutter\bin\flutter doctor -v || GOTO :END
 @ECHO ON
+
+# Put Flutter at the start of the PATH because the OS image may contain
+# another version of Flutter.
+SET PATH=%CD%\flutter/bin;%CD%\flutter\bin\cache\dart-sdk\bin;%PATH%
 
 @ECHO.
 @ECHO.

--- a/scripts/verify_tests_on_master.sh
+++ b/scripts/verify_tests_on_master.sh
@@ -22,10 +22,13 @@ case $key in
 esac
 done
 
-# Switch to Flutter master.
-flutter channel master
-flutter upgrade
-flutter doctor -v
+# Fetch Flutter.
+git clone https://github.com/flutter/flutter.git
+flutter/bin/flutter doctor -v
+
+# Put Flutter at the start of the PATH because the OS image may contain
+# another version of Flutter.
+export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:"$PATH"
 
 cd flutter/dev/customer_testing
 dart pub get

--- a/scripts/verify_tests_on_master.sh
+++ b/scripts/verify_tests_on_master.sh
@@ -22,13 +22,10 @@ case $key in
 esac
 done
 
-# Fetch Flutter.
-git clone https://github.com/flutter/flutter.git
-flutter/bin/flutter doctor -v
-
-# Put Flutter at the start of the PATH because the OS image may contain
-# another version of Flutter.
-export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:"$PATH"
+# Switch to Flutter master.
+flutter channel master
+flutter upgrade
+flutter doctor -v
 
 cd flutter/dev/customer_testing
 dart pub get

--- a/scripts/verify_tests_on_master.sh
+++ b/scripts/verify_tests_on_master.sh
@@ -26,7 +26,9 @@ done
 git clone https://github.com/flutter/flutter.git
 flutter/bin/flutter doctor -v
 
-export PATH="$PATH":`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin
+# Put Flutter at the start of the PATH because the OS image may contain
+# another version of Flutter.
+export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:"$PATH"
 
 cd flutter/dev/customer_testing
 dart pub get


### PR DESCRIPTION
This updates https://github.com/DanTup/tiler to a version that has separate golden images for macOS Intel and macOS M1 because the produces images are not identical (see https://github.com/flutter/flutter/issues/118258#issuecomment-1387362550).

The change: https://github.com/DanTup/tiler/commit/3cb0cad96cc393b85cf7e38c4623cc16390f906e#diff-e3add028a0a83d042c0fbf2778df8b172734500140479f80f48354c8373894f9

It also switches Cirrus to M1 Macs (essentially https://github.com/flutter/tests/pull/204) because the old Intel Mac bots are not available and fail immediately.

Fixes https://github.com/flutter/flutter/issues/118258.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
