### PR TITLE
Add `macos_ui` to customer testing

### DIFF
--- a/registry/macos_ui.test
+++ b/registry/macos_ui.test
@@ -1,7 +1,7 @@
 contact=groovinchip@gmail.com
 
 fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
-fetch=git -C tests checkout ae5dc52a3b0da21eccffff23088376afa7bd59d2
+fetch=git -C tests checkout 9894aba0f41daba377cda399b4aa5a4d8ee8fac0
 
 update=.
 

--- a/registry/macos_ui.test
+++ b/registry/macos_ui.test
@@ -1,0 +1,9 @@
+contact=groovinchip@gmail.com
+
+fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
+fetch=git -C tests checkout ae5dc52a3b0da21eccffff23088376afa7bd59d2
+
+update=.
+
+test=flutter analyze --no-fatal-infos
+test=flutter test

--- a/registry/macos_ui.test
+++ b/registry/macos_ui.test
@@ -1,7 +1,7 @@
 contact=groovinchip@gmail.com
 
 fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
-fetch=git -C tests checkout 9894aba0f41daba377cda399b4aa5a4d8ee8fac0
+fetch=git -C tests checkout 02cd1834030e70c8fb2069c3837722d5cfded8c0
 
 update=.
 

--- a/registry/macos_ui.test
+++ b/registry/macos_ui.test
@@ -1,7 +1,7 @@
 contact=groovinchip@gmail.com
 
 fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
-fetch=git -C tests checkout 02cd1834030e70c8fb2069c3837722d5cfded8c0
+fetch=git -C tests checkout 411d00d56f17f68beaefb0fc0e8c817b343c4a03
 
 update=.
 


### PR DESCRIPTION
This PR adds [`macos_ui`](https://pub.dev/packages/macos_ui) to the registry of customer tests.

Closes https://github.com/flutter/flutter/issues/119940

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing. (I ran the customer tests locally per the tests repo `README`)

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
