### PR TITLE
Bumped rfw test hash

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,21 @@
 task:
   name: tests-linux-0
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 0
+  script: scripts/verify_tests_on_master.sh --shards 3 --shard-index 0
   container:
     image: gcc:latest
 
 task:
   name: tests-linux-1
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
-  script: scripts/verify_tests_on_master.sh --shards 2 --shard-index 1
+  script: scripts/verify_tests_on_master.sh --shards 3 --shard-index 1
+  container:
+    image: gcc:latest
+
+task:
+  name: tests-linux-2
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  script: scripts/verify_tests_on_master.sh --shards 3 --shard-index 2
   container:
     image: gcc:latest
 

--- a/registry/flutter_packages.test
+++ b/registry/flutter_packages.test
@@ -9,6 +9,6 @@ contact=ian@hixie.ch
 update=packages/rfw
 
 fetch=git -c core.longPaths=true clone https://github.com/flutter/packages.git tests
-fetch=git -c core.longPaths=true -C tests checkout cd336474756ea8e120d0c0146398b5a9c76fa229
+fetch=git -c core.longPaths=true -C tests checkout 789e3a72c9d439336bb50e5d291128347f7f6967
 test.windows=.\customer_testing.bat
 test.posix=./customer_testing.sh


### PR DESCRIPTION
Engine->Flutter roll seems to be blocked on a few issues, the version constraint of rfw tests is one of them.

issue: https://github.com/flutter/flutter/issues/122723
example failure this addresses: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20customer_testing/50199/overview

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
