### PR TITLE
Re-enable macosui tests with new hash

### DIFF
--- a/registry/macos_ui.test
+++ b/registry/macos_ui.test
@@ -1,10 +1,9 @@
 contact=groovinchip@gmail.com
 
 fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
-fetch=git -C tests checkout 411d00d56f17f68beaefb0fc0e8c817b343c4a03
+fetch=git -C tests checkout 539b8cc4b14d6911909ff15eff52521a8fba76aa
 
 update=.
 
 test=flutter analyze --no-fatal-infos
-# TODO(goderbauer): Enable again when https://github.com/flutter/flutter/issues/123669 is fixed upstream.
-# test=flutter test
+test=flutter test


### PR DESCRIPTION
Re-enabling the macosui tests that were failing per this issue filed in flutter/flutter: https://github.com/flutter/flutter/issues/123669

The PR fixing the issue in customer's repo: https://github.com/macosui/macos_ui/pull/402

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
