### PR TITLE
Reduce the number of times super_editor tests run

### DIFF
--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -3,6 +3,11 @@
 # Contacts
 contact=flutterbountyhunters@gmail.com
 
+# These tests take a long time (more than 4 minutes) but have been
+# exempted from the requirement that they run in less than 10s because
+# of their importance in testing our text-editing primitives.
+iterations=2
+
 # Update
 update=attributed_text/
 update=super_text_layout/
@@ -15,18 +20,3 @@ fetch=git -C tests checkout 6b483499ffd8aa09750cb23d9a22f9f5490f8df3
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh
 test.windows=.\flutter_test_registry\flutter_test_repo_test.bat
-
-# To test your tests, check out the flutter/flutter repository and
-# then, from the root of that repository, run:
-#
-#   bin/flutter; cd dev/customer_testing; flutter pub get; time ../../bin/cache/dart-sdk/bin/dart run_tests.dart --repeat=100 <path>
-#
-# ...where <path> is the path to this file.
-#
-# This should run with no output, without failing, and should in total
-# take less than 15 minutes (a hundred runs of your tests taking just
-# a few seconds each). If your tests take longer, mention this in your
-# PR and we will evaluate them to see how valuable they are (e.g. how
-# unique and different they are compared to other tests we already
-# have). The more valuable the tests, the more likely we are to accept
-# them despite them taking a long time to run.


### PR DESCRIPTION
They seem to take a weirdly long time on Windows (>4min) which makes the shards take a very long time (or time out) when doing the flake shakedown runs.