### PR TITLE
Updates reference for `super_editor` tests to the latest stable.

### DIFF
--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -15,7 +15,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout 4c9dbe8bdf371c058ce38383c8c4b1aeda6da5f2
+fetch=git -C tests checkout 869a5723a268f0103828b86579a247bb546b237a
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh

--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -15,7 +15,7 @@ update=super_editor/
 
 # Fetch the super_editor mono repo.
 fetch=git clone https://github.com/superlistapp/super_editor.git tests
-fetch=git -C tests checkout 0e955079e60619c3ff3ebefd713e7ae7c66a05b5
+fetch=git -C tests checkout 4c9dbe8bdf371c058ce38383c8c4b1aeda6da5f2
 
 # Run the tests.
 test.posix=./flutter_test_registry/flutter_test_repo_test.sh


### PR DESCRIPTION
The most recent update on `super_editor` updates their dependency on `golden_toolkit`. The version previously being used referenced the deprecated `TestWidgetsFlutterBinding.addTime` method which caused failures on [flutter #129663](https://github.com/flutter/flutter/pull/129663).

Working towards [flutter #129654](https://github.com/flutter/flutter/issues/129654).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
