### PR TITLE
Temporarily disable super_editor tests

### DIFF
--- a/registry/super_editor.test
+++ b/registry/super_editor.test
@@ -18,5 +18,12 @@ fetch=git clone https://github.com/superlistapp/super_editor.git tests
 fetch=git -C tests checkout 865a559bf27ef39c8c8554f9343cd89abf8621dd
 
 # Run the tests.
-test.posix=./flutter_test_registry/flutter_test_repo_test.sh
-test.windows=.\flutter_test_registry\flutter_test_repo_test.bat
+
+# Temporarily disable tests while
+#   https://github.com/flutter/flutter/pull/136854 and
+#   https://github.com/superlistapp/super_editor/pull/1593 land.
+
+#test.posix=./flutter_test_registry/flutter_test_repo_test.sh
+#test.windows=.\flutter_test_registry\flutter_test_repo_test.bat
+
+test=echo Temporarily disabled


### PR DESCRIPTION
## Description

This temporarily disables the super_editor tests while https://github.com/flutter/flutter/pull/136854 and https://github.com/superlistapp/super_editor/pull/1593 are landed, to avoid a lot of churn in the super_editor repo.

## Related Issues
 - https://github.com/flutter/flutter/issues/136419
