### PR TITLE
Disable non-hermetic tests of macos_ui

### DIFF
--- a/registry/macos_ui.test
+++ b/registry/macos_ui.test
@@ -1,9 +1,14 @@
 contact=groovinchip@gmail.com
 
-fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
-fetch=git -C tests checkout c6d37d88e38bddc0723fee9eb57c146aa9f0053d
+# Disable macos_ui tests due to them not being hermetic.
+# - Github issue: https://github.com/macosui/macos_ui/issues/499
 
-update=.
+test=echo macos_ui tests are disabled
 
-test=flutter analyze --no-fatal-infos
-test=flutter test
+#fetch=git clone https://github.com/GroovinChip/macos_ui.git tests
+#fetch=git -C tests checkout c6d37d88e38bddc0723fee9eb57c146aa9f0053d
+
+#update=.
+
+#test=flutter analyze --no-fatal-infos
+#test=flutter test


### PR DESCRIPTION
Some tests in `macos_ui` are not hermetic. This PR disabled them in order to unblock the Flutter tree.

Issue filed: https://github.com/macosui/macos_ui/issues/499