### PR TITLE
Remove flutter gallery test

### DIFF
--- a/registry/flutter_gallery.test
+++ b/registry/flutter_gallery.test
@@ -1,7 +1,0 @@
-contact=plg@google.com
-fetch=git -c core.longPaths=true clone https://github.com/flutter/gallery.git tests
-# If you bump this here, you may also want to bump it for the devicelab tests, at:
-# dev/devicelab/lib/versions/gallery.dart in the flutter repo.
-fetch=git -c core.longPaths=true -C tests checkout fa031bfe9d131010e7a56ee5d343f9f85b367d64
-update=.
-test=flutter analyze --no-fatal-infos


### PR DESCRIPTION
Since we are going to shut down Flutter Gallery, remove this test to unblock https://github.com/flutter/flutter/pull/138521.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.