### PR TITLE
Re-enable DevTools tests in Flutter customer service registry

### DIFF
--- a/registry/flutter_devtools.test
+++ b/registry/flutter_devtools.test
@@ -3,7 +3,7 @@
 contact=dart-devtools-eng@google.com
 
 fetch=git clone https://github.com/flutter/devtools.git tests
-fetch=git -C tests checkout b95d4fa394cbc813289662b2c77d9caa6a43938d
+fetch=git -C tests checkout 37de24711c0b4f7bb733dc1c25c66b51e81ed95d
 
 setup.linux=./tool/flutter_customer_tests/setup.sh >> output.txt
 


### PR DESCRIPTION
This PR re-enables DevTools customer testing and updates the hash in `registry/flutter_devtools.test` to make the testing procedure check out a version of DevTools compatible with `package:vm_service ^14.0.0`,

This is the final step in the process described here: https://github.com/flutter/flutter/issues/140169#issuecomment-1920188266.