### PR TITLE
Update flutter_devtools.test hash

### DIFF
--- a/registry/flutter_devtools.test
+++ b/registry/flutter_devtools.test
@@ -3,7 +3,7 @@
 contact=dart-devtools-eng@google.com
 
 fetch=git -c core.longPaths=true clone https://github.com/flutter/devtools.git tests
-fetch=git -c core.longPaths=true -C tests checkout aeb3d7b9f2860cfd012bf97b2e00a29ffa675e34
+fetch=git -c core.longPaths=true -C tests checkout 7ecbaaeb46ef0061e0c02fad43add704d484bc03
 
 setup.linux=./tool/flutter_customer_tests/setup.sh >> output.txt
 


### PR DESCRIPTION
this hash includes https://github.com/flutter/devtools/pull/6942, which unskips an inspector test.