### PR TITLE
Update flutter_packages.test

### DIFF
--- a/registry/flutter_packages.test
+++ b/registry/flutter_packages.test
@@ -9,7 +9,7 @@ contact=ian@hixie.ch
 update=packages/rfw
 
 fetch=git -c core.longPaths=true clone https://github.com/flutter/packages.git tests
-fetch=git -c core.longPaths=true -C tests checkout 1da11759b4a58deb5bd37432af3410f47e0e9c7b
+fetch=git -c core.longPaths=true -C tests checkout a757073ac4eaf05b7516d3d0488e5c98b221043f
 test.windows=set USE_FLUTTER_TEST_FONT=1
 test.windows=.\customer_testing.bat
 test.posix=env USE_FLUTTER_TEST_FONT=1 ./customer_testing.sh


### PR DESCRIPTION
Similar to https://github.com/flutter/tests/pull/297 and https://github.com/flutter/tests/pull/276

Unblocks https://github.com/flutter/flutter/pull/144467#issuecomment-1973161562

This updates the 6 months old packages commit which blocks a Flutter PR as its unable to test newer versions of the packages. 