### PR TITLE
Add zulip.test

### DIFF
--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -2,7 +2,7 @@ contact=greg@zulip.com
 contact=cbobbe@zulip.com
 
 fetch=git clone https://github.com/zulip/zulip-flutter.git tests
-fetch=git -C tests checkout 316cc1a7cc723bc01235cfa31f6cc5ae2836fda6
+fetch=git -C tests checkout 9ea05846858fe36a9820f01917eebce466cb8456
 
 update=.
 update=packages/zulip_plugin

--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -1,0 +1,11 @@
+contact=greg@zulip.com
+contact=cbobbe@zulip.com
+
+fetch=git clone https://github.com/zulip/zulip-flutter.git tests
+fetch=git -C tests checkout 316cc1a7cc723bc01235cfa31f6cc5ae2836fda6
+
+update=.
+update=packages/zulip_plugin
+
+test=flutter analyze --no-fatal-infos
+test=flutter test

--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -7,5 +7,5 @@ fetch=git -C tests checkout 9ea05846858fe36a9820f01917eebce466cb8456
 update=.
 update=packages/zulip_plugin
 
-test=flutter analyze --no-fatal-infos
-test=flutter test
+test.posix=flutter analyze --no-fatal-infos
+test.posix=flutter test


### PR DESCRIPTION
Zulip is an open-source team chat app, with a new Flutter-based mobile client now in beta.  This is that client's test suite.

I believe these will be the only tests currently in this registry for an app, rather than a library.  That should naturally give them a different mix of use cases and types of tests.

Concretely, we've seen a handful of breaking changes over the past year that weren't caught by any of Flutter's existing test suites. These were in text hit-testing:
  https://github.com/zulip/zulip-flutter/commit/ba7a2bfe50aa99d79a03535ade4eab252d07c9e7
  https://github.com/flutter/flutter/pull/140621

and Material menu behavior:
  https://github.com/zulip/zulip-flutter/commit/38ed6c812defcb5da8c2d9185e95fc2eaf1eb37b
  https://github.com/flutter/flutter/pull/130536

and SlottedContainerRenderObjectMixin gaining a type parameter:
  https://github.com/zulip/zulip-flutter/commit/2f0f4692f2d55748d055ac7c140ab7414307a36d
  https://github.com/flutter/flutter/pull/126108

I'm not complaining, to be clear, and none of these were particularly onerous for us to adapt to.  By registering these tests, I'm hoping to provide feedback on future such breakages at a point where it's actionable.

Omitted here are several tests that re-generate generated files and check they match what's in the tree.  Those are pretty slow, and I think they're pretty insensitive to changes in the Flutter tree anyway; rather they depend on pigeon, json_serializable, build_runner, and drift_dev.

