### PR TITLE
Reenable DevTools tests.

### DIFF
--- a/registry/flutter_devtools.test
+++ b/registry/flutter_devtools.test
@@ -3,7 +3,7 @@
 contact=dart-devtools-eng@google.com
 
 fetch=git -c core.longPaths=true clone https://github.com/flutter/devtools.git tests
-fetch=git -c core.longPaths=true -C tests checkout e77d6ce142b7bc737af3652f5727e449e84b7b03
+fetch=git -c core.longPaths=true -C tests checkout 3601dafcbbc8ab9c7b7fb210e763140d6e755762
 
 setup.linux=./tool/flutter_customer_tests/setup.sh >> output.txt
 


### PR DESCRIPTION
This reverts https://github.com/flutter/tests/pull/397 and updates the DevTools hash to the tip of master.