### PR TITLE
Restore the Zulip test and roll forward to a commit with upgraded flutter_color_models

### DIFF
--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -2,7 +2,7 @@ contact=greg@zulip.com
 contact=cbobbe@zulip.com
 
 fetch=git clone https://github.com/zulip/zulip-flutter.git tests
-fetch=git -C tests checkout cdbe14122eac145afaa86d19f152b5451e3c457b
+fetch=git -C tests checkout 753a9b4b35d652632f61c18a7ba7b7ef83053a3e
 
 update=.
 update=packages/zulip_plugin


### PR DESCRIPTION
Previous change that disabled the test:
* https://github.com/flutter/tests/pull/421