### PR TITLE
feat: re-enable flutter_rfb

### DIFF
--- a/registry/flutter_rfb.test
+++ b/registry/flutter_rfb.test
@@ -1,6 +1,6 @@
 contact=goddchen@gmail.com
 fetch=git clone https://github.com/Goddchen/flutter-rfb.git tests
-fetch=git -C tests checkout b7aa339c5534b54a63674df64b26dfb86414b815
+fetch=git -C tests checkout d25388736c8f3908fd2224f5f707385056de855e
 update=.
 test=flutter analyze --no-fatal-infos
 test=flutter test


### PR DESCRIPTION
Since I have merged this PR that removes the obsolete lint rules: https://github.com/Goddchen/flutter-rfb/pull/24

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
