### PR TITLE
Update `zulip.test` to latest SHA.

### DIFF
--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -2,7 +2,7 @@ contact=greg@zulip.com
 contact=cbobbe@zulip.com
 
 fetch=git clone https://github.com/zulip/zulip-flutter.git tests
-fetch=git -C tests checkout 753a9b4b35d652632f61c18a7ba7b7ef83053a3e
+fetch=git -C tests checkout 28b3536bc81b6665a6014ce72f40c51f83b0c5c4
 
 update=.
 update=packages/zulip_plugin


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/160257.

Zulip recently removed usages of `flutter_gen`, which are deprecated pending removal.