### PR TITLE
Re-land "Update Zulip tests and re-enable (#441)"

### DIFF
--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -2,7 +2,9 @@ contact=greg@zulip.com
 contact=cbobbe@zulip.com
 
 fetch=git clone https://github.com/zulip/zulip-flutter.git tests
-fetch=git -C tests checkout 28b3536bc81b6665a6014ce72f40c51f83b0c5c4
+fetch=git -C tests checkout f5d2a456b438e2ab6b5c6d59593bd0203ed9286d
+
+setup.linux=tools/customer-testing/setup.sh
 
 update=.
 update=packages/zulip_plugin

--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -2,7 +2,7 @@ contact=greg@zulip.com
 contact=cbobbe@zulip.com
 
 fetch=git clone https://github.com/zulip/zulip-flutter.git tests
-fetch=git -C tests checkout f5d2a456b438e2ab6b5c6d59593bd0203ed9286d
+fetch=git -C tests checkout ae7939afabb4c6a32fa5ffd0be03928467c8cd64
 
 setup.linux=tools/customer-testing/setup.sh
 


### PR DESCRIPTION
This re-lands 8cf7a67e450069962ec14335cc47e4d980e23f30 / #441.

Difference from previous version: This version has the new setup step do its work only where `sudo` is available (in GitHub Actions), and successfully do nothing where it's unavailable (in LUCI).  The step isn't needed in LUCI.

The logic lives in a setup script added today to the Zulip tree:
  https://github.com/zulip/zulip-flutter/pull/1300

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
