### PR TITLE
Bump Zulip pin to update some tests that hard-code route animation duration

### DIFF
--- a/registry/zulip.test
+++ b/registry/zulip.test
@@ -2,7 +2,7 @@ contact=greg@zulip.com
 contact=cbobbe@zulip.com
 
 fetch=git clone https://github.com/zulip/zulip-flutter.git tests
-fetch=git -C tests checkout 88e7bccd663f9e1f6eb9e7f4bb19fb8ffd011391
+fetch=git -C tests checkout 834834b514ebc019f6ed80785d792009eb29a1e0
 
 setup.linux=tools/customer-testing/setup.sh
 


### PR DESCRIPTION
This updates to the following change in Zulip:
  https://github.com/zulip/zulip-flutter/commit/834834b514ebc019f6ed80785d792009eb29a1e0
  https://github.com/zulip/zulip-flutter/pull/1547

in order to unblock this PR:
  https://github.com/flutter/flutter/pull/165832

> [!IMPORTANT]
> This repository is a testing suite that contains references to tests (in the `registry` directory) that are run with every commit to Flutter
> to verify that no breaking changes have been introduced (in the "customer_testing" shards). Your merged PR is _not_ automatically run in the
> Flutter CI tree.
>
> After merging this PR, you must send another PR to flutter/flutter updating `dev/customer_testing/tests.version` in that repo with the latest git commit SHA of the flutter/test repo.
>
> See <https://github.com/flutter/flutter/pull/162048> for details.
