### PR TITLE
Bump assorted_layout_widgets to d07de6a67b54d534612329896e78e3e7941fff32

### DIFF
--- a/registry/assorted_layout_widgets.test
+++ b/registry/assorted_layout_widgets.test
@@ -1,7 +1,7 @@
 contact=marcglasberg@gmail.com
 contact=pascal@pascalwelsch.com
 fetch=git clone https://github.com/marcglasberg/assorted_layout_widgets.git tests
-fetch=git -C tests checkout e32fabf854927bb4c0c0284624bf30c20c4aab8d
+fetch=git -C tests checkout d07de6a67b54d534612329896e78e3e7941fff32
 update=.
 test=flutter analyze --no-fatal-infos
 test=flutter test


### PR DESCRIPTION
This bumps `assorted_layout_widgets` to the latest version. The current version is around 10 months old and excludes some changes made to remove obsolete lints that are preventing landing a change to the analysis server to produce warnings for that.

Specifically, we want the PR from @pq merged at https://github.com/marcglasberg/assorted_layout_widgets/pull/37 that removes `prefer_equal_for_default_values` to unblock @FMorschel's change at https://dart-review.googlesource.com/c/sdk/+/448063.