### PR TITLE
Add Flame engine to the registry

### DIFF
--- a/registry/flame.test
+++ b/registry/flame.test
@@ -13,7 +13,7 @@ contact=contact@blue-fire.xyz
 contact=lukas@blue-fire.xyz
 
 fetch=git clone https://github.com/flame-engine/flame.git tests
-fetch=git -C tests checkout 2642e0eebcfa868ab81a06691f5fca74f3db5ae6
+fetch=git -C tests checkout 9bf726630764bb25125cfc84dbddf1cec1e879de
 
 update=.
 

--- a/registry/flame.test
+++ b/registry/flame.test
@@ -1,0 +1,20 @@
+# Tests from https://github.com/flame-engine/flame
+#
+# Flame is a monorepo managed as a pub workspace, so the "update" step below
+# (flutter pub get at the repository root) resolves every member package.
+#
+# The test command runs scripts/customer_testing.dart in the Flame repository,
+# which works identically on every platform. It runs flutter analyze over the
+# whole workspace everywhere; the full per-package "flutter test" suites run on
+# Linux only, because Flame's golden and rendering tests are platform-sensitive
+# (this mirrors flutter/packages' own registry entry).
+
+contact=contact@blue-fire.xyz
+contact=lukas@blue-fire.xyz
+
+fetch=git clone https://github.com/flame-engine/flame.git tests
+fetch=git -C tests checkout c706078691b29a2e5f41f494fb05d059474a0c84
+
+update=.
+
+test=dart run scripts/customer_testing.dart

--- a/registry/flame.test
+++ b/registry/flame.test
@@ -13,7 +13,7 @@ contact=contact@blue-fire.xyz
 contact=lukas@blue-fire.xyz
 
 fetch=git clone https://github.com/flame-engine/flame.git tests
-fetch=git -C tests checkout c706078691b29a2e5f41f494fb05d059474a0c84
+fetch=git -C tests checkout 2642e0eebcfa868ab81a06691f5fca74f3db5ae6
 
 update=.
 

--- a/registry/flame.test
+++ b/registry/flame.test
@@ -13,7 +13,7 @@ contact=contact@blue-fire.xyz
 contact=lukas@blue-fire.xyz
 
 fetch=git clone https://github.com/flame-engine/flame.git tests
-fetch=git -C tests checkout a308e70cc39eff74dc91d28edd55a79a48afd071
+fetch=git -C tests checkout 74721f093645603001b205ca9c36c94c5552a1fd
 
 update=.
 

--- a/registry/flame.test
+++ b/registry/flame.test
@@ -13,7 +13,7 @@ contact=contact@blue-fire.xyz
 contact=lukas@blue-fire.xyz
 
 fetch=git clone https://github.com/flame-engine/flame.git tests
-fetch=git -C tests checkout 9bf726630764bb25125cfc84dbddf1cec1e879de
+fetch=git -C tests checkout a308e70cc39eff74dc91d28edd55a79a48afd071
 
 update=.
 


### PR DESCRIPTION
Adds the [Flame engine](https://github.com/flame-engine/flame) to the customer test registry so that its tests run as a presubmit against `flutter/flutter` framework changes.

### How it works

Flame is a monorepo managed as a **pub workspace**, so the `update` step (`flutter pub get` at the repo root) resolves every member package in one go. The test command runs `scripts/customer_testing.dart` in the Flame repository, which works identically on every platform (no separate `.sh`/`.bat` needed):

- `flutter analyze --no-fatal-infos` runs over the whole workspace on **every platform**.
- The full per-package `flutter test` suites (27 packages) run on **Linux only**, because Flame's golden and rendering tests are platform-sensitive. This mirrors how `flutter/packages` handles its own registry entry.

### Notes for reviewers

- The pinned revision points at the branch commit of flame-engine/flame#3941, which adds `scripts/customer_testing.dart`. **Once that PR merges I'll update the SHA here to the resulting `main` commit** before this lands.
- Flame's full suite (~300 test files) is larger than a few-seconds suite. Analyze is fast on all platforms; the Linux test run is where the bulk of the time goes. Happy to trim the package set if the total runtime is a concern.
- An earlier attempt to register Flame lived on the old `master` branch and predates pub workspaces (it relied on `melos bootstrap`); this replaces that approach.

Locally verified that root `flutter pub get` resolves the workspace, the analyze pass is clean over the whole tree, and per-package `flutter test` works.