### PR TITLE
Add supabase-flutter to the registry

### DIFF
--- a/registry/supabase_flutter.test
+++ b/registry/supabase_flutter.test
@@ -9,7 +9,7 @@
 contact=lukas.klingsbo@supabase.io
 
 fetch=git clone https://github.com/supabase/supabase-flutter.git tests
-fetch=git -C tests checkout 61b2118c7479d26d0a267dd06396b7d9e1e1809f
+fetch=git -C tests checkout afad09decbbf4c0ccd91c5a147041646b26830fc
 
 update=.
 

--- a/registry/supabase_flutter.test
+++ b/registry/supabase_flutter.test
@@ -1,0 +1,16 @@
+# Tests from https://github.com/supabase/supabase-flutter
+#
+# supabase-flutter is a pub workspace, so the "update" step below (flutter pub get at
+# the repository root) resolves every member package. The test step runs
+# scripts/customer_testing.dart, which runs `flutter analyze --no-fatal-infos` over the
+# whole workspace and `flutter test` in packages/supabase_flutter. The other packages
+# are excluded because their tests require a live Supabase backend.
+
+contact=lukas.klingsbo@supabase.io
+
+fetch=git clone https://github.com/supabase/supabase-flutter.git tests
+fetch=git -C tests checkout 61b2118c7479d26d0a267dd06396b7d9e1e1809f
+
+update=.
+
+test=dart run scripts/customer_testing.dart


### PR DESCRIPTION
Adds a registry entry for [supabase-flutter](https://github.com/supabase/supabase-flutter), the official Supabase client library for Flutter/Dart, so that framework changes are checked against its tests as a presubmit.

Follows the same pattern as the Flame entry (#489): the entry clones supabase-flutter at a pinned commit and runs `scripts/customer_testing.dart`, which:

1. Runs `flutter analyze --no-fatal-infos` over the whole pub workspace (covers every member package).
2. Runs `flutter test` in `packages/supabase_flutter`.

Only `supabase_flutter` is exercised because it is hermetic (mock/stub based). The repo's other packages have tests that require a live Supabase backend, so they are not included here.

The `scripts/customer_testing.dart` script is added in supabase/supabase-flutter#1528.

contact: lukas.klingsbo@supabase.io